### PR TITLE
feat(core, vue): auto calc width and height of renderer

### DIFF
--- a/packages/core/src/Digm.ts
+++ b/packages/core/src/Digm.ts
@@ -34,11 +34,15 @@ export interface FetchRenderUrlOptions {
 
   /**
    * 输出像素宽度
+   *
+   * 可选，默认为容器宽度
    */
   width?: number
 
   /**
    * 输出像素高度
+   *
+   * 可选，默认为容器高度
    */
   height?: number
 }
@@ -65,6 +69,8 @@ export type StatusSubscriber = (status: RenderStatus) => void | Promise<void>
 export type CloudRendererType = typeof CloudRenderer
 
 export class Digm {
+  private _el: Element
+
   private _renderer: CloudRendererType
 
   get renderer(): CloudRendererType {
@@ -128,14 +134,19 @@ export class Digm {
    */
   init(idOrElement: string | Element) {
     this.status = RenderStatus.INIT_RENDER
+
+    // init render required a string id
+    // we also need to record the element
     let id: string
     if (idOrElement instanceof Element) {
       const existId = !!idOrElement.id
-      id = existId ? idOrElement.id : (idOrElement.id = Math.random().toString().slice(2))
+      id = existId ? idOrElement.id : (idOrElement.id = `digm-${Math.random().toString().slice(2)}`)
+      this._el = idOrElement
     } else {
-      if (!document.querySelector(`#${idOrElement}`))
-        throw new Error(`[Error] Element #${idOrElement}} is not exists.`)
+      const el = document.getElementById(idOrElement)
+      if (!el) throw new Error(`[Error] Element #${idOrElement}} is not exists.`)
       id = idOrElement
+      this._el = el
     }
 
     try {
@@ -153,10 +164,13 @@ export class Digm {
   async startEngine(options: StartEngineOptions) {
     if (!options.url) throw new Error(`[Error] options.url is required`)
     if (!options.order) throw new Error(`[Error] options.order is required`)
-    if (!options.width) throw new Error(`[Error] options.width is required`)
-    if (!options.height) throw new Error(`[Error] options.height is required`)
 
     this._verifyStatus()
+
+    // If the user does not specify a width and height,
+    // use the width and height of the container element
+    options = Object.assign(getElementWidthAndHeight(this._el), options)
+
     /**
      * - fetch renderUrl
      * - set renderer log, bind global event handler
@@ -245,4 +259,8 @@ export class Digm {
 
 export function createDigm(...args: ConstructorParameters<typeof Digm>) {
   return new Digm(...args)
+}
+
+function getElementWidthAndHeight(el: Element) {
+  return { width: el.clientWidth, height: el.clientHeight }
 }

--- a/packages/vue/src/components/DigmV.vue
+++ b/packages/vue/src/components/DigmV.vue
@@ -7,15 +7,6 @@ import DigmMask from './DigmMask.vue'
 
 type Props = {
   /**
-   * 填充大小
-   *
-   * - `viewport`: 撑满视口，即 100vw,100vh
-   * - `container`: 撑满父容器，即 100%,100%
-   *
-   * 默认值: `viewport`
-   */
-  fill?: 'viewport' | 'container'
-  /**
    * 渲染服务器 baseUrl
    */
   url: string
@@ -41,11 +32,27 @@ type Props = {
    * 默认值: `false`
    */
   debugPanel?: boolean
+  /**
+   * 组件显示大小
+   *
+   * - `viewport`: 撑满视口，即 100vw,100vh
+   * - `container`: 撑满父容器，即 100%,100%
+   *
+   * 默认值: `viewport`
+   */
+  size?: 'viewport' | 'container'
+  /**
+   * 是否使用默认的等待遮罩层
+   *
+   * 默认值: true
+   */
+  mask?: boolean
 }
 const props = withDefaults(defineProps<Props>(), {
-  size: 'viewport',
   enableLog: false,
   sleepTime: 5000,
+  size: 'viewport',
+  mask: true,
 })
 
 const emit = defineEmits<{
@@ -55,13 +62,12 @@ const emit = defineEmits<{
 
 const digmRef = ref<Element>()
 
+// Renderer width and height are auto calc based on the container size
 const { status, isReady } = useDigm({
   autoStart: true,
   target: digmRef as Ref<Element>,
   url: props.url,
   order: props.order,
-  width: window.innerWidth,
-  height: window.innerHeight,
   enableLog: props.enableLog,
   sleepTime: props.sleepTime,
 })
@@ -72,7 +78,7 @@ watchEffect(() => isReady.value && emit('ready'))
 
 <template>
   <div :class="['digm-v', `digm-v__${props.size}`]" ref="digmRef"></div>
-  <DigmMask></DigmMask>
+  <DigmMask v-if="props.mask" />
 </template>
 
 <style>


### PR DESCRIPTION
Affected package:
- digm-core
- digm-vue

## digm-core

In `digm.startEngine()` if the user does not specify a `width` and `height`, use the width and height of the container element

用户如果在调用 `digm.startEngine()` 时没有指定 `width` 和 `height`，将使用容器元素的宽高

## digm-vue

Use the above new features in the `DigmV` component to automatically calculate the width and height
Support new props `mask` to enable or disable default `DigmMask`

在 `DigmV` 组件中使用上述新特性自动计算宽高
支持新的 props `mask` 来启/禁用默认的 `DigmMask`

