### PR TITLE
chore: handle any type warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "pnpm -r --filter !playground build",
     "build:pg": "pnpm --filter playground build",
     "test": "exit 0;",
-    "lint": "eslint packages/*/src/**.ts",
+    "lint": "eslint packages/*/src/**/*.ts",
     "format": "prettier --write --parser typescript \"packages/**/*.ts\"",
     "commit": "git-cz"
   },

--- a/packages/core/src/features/BaseFeature.ts
+++ b/packages/core/src/features/BaseFeature.ts
@@ -1,5 +1,6 @@
-import { Digm } from '../Digm'
+import type { Digm } from '../Digm'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FeatureResult<T = any> = {
   func_name: string
   success: boolean

--- a/packages/core/src/features/Covering.ts
+++ b/packages/core/src/features/Covering.ts
@@ -257,6 +257,7 @@ export type resultItem = {
 
 export type GetCustomizeApiResult = FeatureResult & {
   result: resultItem[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any
 }
 

--- a/packages/core/src/features/Path.ts
+++ b/packages/core/src/features/Path.ts
@@ -124,6 +124,7 @@ export type AddGeoPathOptions = Omit<AddPathOptions, 'points'> & {
   /**
    * geojson 文件路径 或 对象
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   geojson: any
 }
 

--- a/packages/core/src/features/Range.ts
+++ b/packages/core/src/features/Range.ts
@@ -103,6 +103,7 @@ export type AddGeoRangeOptions = RangeIDOptions &
     /**
      * 支持json或文件形式、二选一
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     geojson: any
   }
 

--- a/packages/core/src/features/SceneEdit.ts
+++ b/packages/core/src/features/SceneEdit.ts
@@ -83,6 +83,7 @@ export type GetAESObjectDataWithEidsResultItem = {
   location: Location
   rotation: Rotation
   scale: Scale
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any
 }
 

--- a/packages/core/src/features/utils.ts
+++ b/packages/core/src/features/utils.ts
@@ -1,9 +1,11 @@
 import { ensureObject } from '@cphayim/digm-shared'
 
+export type SuperAPI = (...args: unknown[]) => void
+
 /**
  * 适用于仅调用一次回调函数的 superAPI，返回 promise
  */
-export function promiseWrapper(superAPI: any, name: string, params?: unknown) {
+export function promiseWrapper(superAPI: SuperAPI, name: string, params?: unknown) {
   if (__DEV__) {
     console.log(`calling method named ${name}`, params)
   }
@@ -20,9 +22,9 @@ export function promiseWrapper(superAPI: any, name: string, params?: unknown) {
  * 适用于调用多次回调函数的 superAPI，例如：取点工具
  */
 export function callbackWrapper(
-  superAPI: any,
+  superAPI: SuperAPI,
   name: string,
-  callback: (...args: any[]) => unknown,
+  callback: (...args: unknown[]) => unknown,
   params?: unknown,
 ) {
   if (__DEV__) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export const noop = () => void 0
 /**
  * 确保得到一个对象，如果传入的类型是 json 字符串则进行 parse
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function ensureObject<T = any>(obj: unknown): T {
   return typeof obj === 'string' ? JSON.parse(obj) : obj
 }


### PR DESCRIPTION
Handle all warnings for `any` types
Used `unknown` where it could be replaced, disabled eslint where `any` had to be used

处理所有针对 `any` 类型的警告
在可替换处使用了 `unknown`，在必须使用 `any` 的地方禁用了 eslint 