### PR TITLE
feat(core,vue,react): implement render url transformer

### DIFF
--- a/packages/react/src/components/DigmV.tsx
+++ b/packages/react/src/components/DigmV.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, MutableRefObject } from 'react'
 import classNames from 'classnames'
 import { noop } from '@cphayim/digm-shared'
-import type { RenderStatus } from '@cphayim/digm-core'
+import type { RenderStatus, RenderUrlTransformer } from '@cphayim/digm-core'
 import { useDigm } from '../hooks/digm'
 import DigmMask from './DigmMask'
 import './DigmV.css'
@@ -15,6 +15,20 @@ type Props = {
    * 渲染口令
    */
   order: string
+  /**
+   * 转换渲染地址
+   *
+   * 如果传入 `true` 或 `RenderUrlTransformer`，将会对渲染服务器返回的渲染地址进行转换
+   *
+   * 例如前端通过请求网关进行转发的场景 10.1.1.1 (nginx) -> 192.168.0.100 (渲染服务器)，
+   * 此时渲染服务器将返回例如 http://192.168.0.100:8891/{render-token} 的渲染地址，这会导致后续的渲染流程失败
+   *
+   * 当传入 `true` 时：
+   * 该选项解析 `url` 并使用其 `protocol` 和 `hostname` 将渲染地址转换为 `http://10.1.1.1:8891/{render-token}`
+   *
+   * 也可以传入 `RenderUrlTransformer` 来自定义转换逻辑
+   */
+  transformer?: boolean | RenderUrlTransformer
   /**
    * 是否启用渲染器日志
    *
@@ -78,6 +92,7 @@ export const DigmV = (props: Props) => {
     target: digmRef as MutableRefObject<HTMLElement>,
     url: props.url,
     order: props.order,
+    transformer: props.transformer,
     enableLog,
     sleepTime,
   })

--- a/packages/vue/src/components/DigmV.vue
+++ b/packages/vue/src/components/DigmV.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Ref, ref, watchEffect } from 'vue'
 
-import type { RenderStatus } from '@cphayim/digm-core'
+import type { RenderStatus, RenderUrlTransformer } from '@cphayim/digm-core'
 import { useDigm } from '../hooks/digm.js'
 import DigmMask from './DigmMask.vue'
 
@@ -14,6 +14,20 @@ type Props = {
    * 渲染口令
    */
   order: string
+  /**
+   * 转换渲染地址
+   *
+   * 如果传入 `true` 或 `RenderUrlTransformer`，将会对渲染服务器返回的渲染地址进行转换
+   *
+   * 例如前端通过请求网关进行转发的场景 10.1.1.1 (nginx) -> 192.168.0.100 (渲染服务器)，
+   * 此时渲染服务器将返回例如 http://192.168.0.100:8891/{render-token} 的渲染地址，这会导致后续的渲染流程失败
+   *
+   * 当传入 `true` 时：
+   * 该选项解析 `url` 并使用其 `protocol` 和 `hostname` 将渲染地址转换为 `http://10.1.1.1:8891/{render-token}`
+   *
+   * 也可以传入 `RenderUrlTransformer` 来自定义转换逻辑
+   */
+  transformer?: boolean | RenderUrlTransformer
   /**
    * 是否启用渲染器日志
    *
@@ -68,6 +82,7 @@ const { status, isReady } = useDigm({
   target: digmRef as Ref<Element>,
   url: props.url,
   order: props.order,
+  transformer: props.transformer,
   enableLog: props.enableLog,
   sleepTime: props.sleepTime,
 })


### PR DESCRIPTION
In a complex network environment, the rendering service may return a rendering address that is inconsistent with the requested address.

## Affected Packages

- `@cphayim/digm-core`
- `@cphayim/digm-vue`
- `@cphayim/digm-react`

## Features

Provides an extra option `transformer` for the `StartEngineOptions`:

```ts
{
  /**
    * Convert rendering address
    *
    * If `true` or `RenderUrlTransformer` is passed, it will convert the rendering URL returned by the rendering server
    *
    * For example, in the scenario where the front end forwards through the request gateway 10.1.1.1 (nginx) -> 192.168.0.100 (rendering server),
    * At this point, the rendering server will return a rendering address such as http://192.168.0.100:8891/{render-token}, which will cause the subsequent rendering process to fail
    *
    * When passing `true`:
    * This option parses `url` and uses its `protocol` and `hostname` to convert the render address to `http://10.1.1.1:8891/{render-token}`
    *
    * You can also pass in `RenderUrlTransformer` to customize the transformation logic
    */
   transformer?: boolean | RenderUrlTransformer
}
```

## Usege

### For Vailla:

```ts
const digm = new Digm()
digm.init(el)
digm.startEngine({
  // ...
  transformer: true
  // ...
})
```

### For Vue: 

Your can pass to `useDigm` hooks or pass it directly to the component `DigmV`

```vue
<script setup lang="ts">
const { digm } = useDigm({
  // pass to hooks
  transformer: true
  // ...
})
</script>

<template>
  <!-- pass to component -->
  <DigmV :url="url" :order="order" transformer />
</template>
```

### For React: 

Your can pass to `useDigm` hooks or pass it directly to the component `DigmV`

```ts
const { digm } = useDigm({
  // pass to hooks
  transformer: true
  // ...
})

// pass to component
return <DigmV url={url} order={order} transformer={true} />
```